### PR TITLE
Fix Lumen env copy + Mysql/Redis ADD fix

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -3,6 +3,7 @@ NAME=microservice-lumen
 
 MYSQL_NAME=microservice-lumen_mysql
 MYSQL_TAG=5.7
+MYSQL_ROOTPW=root
 
 REDIS_NAME=microservice-lumen_redis
 REDIS_TAG=latest

--- a/application/start.sh
+++ b/application/start.sh
@@ -1,0 +1,5 @@
+file="./.env"
+if [ ! -f "$file" ]
+then
+    cp ./.env.example .env
+fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,30 +5,22 @@ services:
   ####################################################################################################
   mysql:
     container_name: ${MYSQL_NAME}_${MYSQL_TAG}
-    image: "${MYSQL_NAME}:${MYSQL_TAG}"
-    build:
-      context: ./
-      dockerfile: ./docker-compose/mysql/Dockerfile
-      args:
-        - TAG=${MYSQL_TAG}
+    image: "mysql:${MYSQL_TAG}"
     ports:
         - "3306:3306"
     expose:
         - 3306
     volumes:
         - ./docker-compose/image/mysql/data/:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOTPW}
 
   ####################################################################################################
   # The Redis Server
   ####################################################################################################
   redis:
     container_name: ${REDIS_NAME}_${REDIS_TAG}
-    image: "${REDIS_NAME}:${REDIS_TAG}"
-    build:
-      context: ./
-      dockerfile: ./docker-compose/redis/Dockerfile
-      args:
-        - TAG=${REDIS_TAG}
+    image: "redis:${REDIS_TAG}"
     ports:
         - "6379:6379"
     expose:
@@ -39,7 +31,7 @@ services:
   # Use it with command: docker-compose run redis-cli
   redis-cli:
     container_name: ${NAME}_redis-cli
-    image: "${REDIS_NAME}:${REDIS_TAG}"
+    image: "redis:${REDIS_TAG}"
     links:
       - redis
     command: redis-cli -h redis

--- a/docker-compose/mysql/Dockerfile
+++ b/docker-compose/mysql/Dockerfile
@@ -1,8 +1,0 @@
-ARG TAG
-
-FROM mysql:$TAG
-
-LABEL maintainer="Fabrizio Cafolla <info@fabriziocafolla.com>"
-
-# ADD data in image when build
-ADD ./docker-compose/image/mysql/data/ /var/lib/mysql

--- a/docker-compose/redis/Dockerfile
+++ b/docker-compose/redis/Dockerfile
@@ -1,8 +1,0 @@
-ARG TAG
-
-FROM redis:$TAG
-
-LABEL maintainer="Fabrizio Cafolla <info@fabriziocafolla.com>"
-
-# ADD data in image when build
-ADD ./docker-compose/image/redis/data /data

--- a/docker-compose/workspace/Dockerfile
+++ b/docker-compose/workspace/Dockerfile
@@ -65,4 +65,4 @@ RUN if [ $COMPOSER_UPDATE = "true" ]; then \
     composer update \
 ;fi
 
-RUN cp ./.env.example .env
+CMD [ "./start.sh" ]


### PR DESCRIPTION
To copy the .env during the first start i used a shell script.
The script check if .env already exist, if not create a new one based on .env.example.

----------
Changed the docker-compose file, remove the `build` attr because `image` do almost the same.
Also remove the mysql and redis dockerfile, now the version is selected directly from docker-compose `image` attribute.