### PR TITLE
'ADD' fix + workspace dockerfile cleaning

### DIFF
--- a/.env.docker
+++ b/.env.docker
@@ -10,7 +10,6 @@ REDIS_TAG=latest
 
 WORKSPACE_NAME=microservice-lumen_app
 WORKSPACE_TAG=7.2.2-fpm
-COMPOSER_UPDATE=true
 
 NGINX_NAME=microservice-lumen_nginx
 NGINX_TAG=1.10

--- a/.env.docker
+++ b/.env.docker
@@ -3,6 +3,7 @@ NAME=microservice-lumen
 
 MYSQL_NAME=microservice-lumen_mysql
 MYSQL_TAG=5.7
+MYSQL_ROOTPW=root
 
 REDIS_NAME=microservice-lumen_redis
 REDIS_TAG=latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,30 +5,22 @@ services:
   ####################################################################################################
   mysql:
     container_name: ${MYSQL_NAME}_${MYSQL_TAG}
-    image: "${MYSQL_NAME}:${MYSQL_TAG}"
-    build:
-      context: ./
-      dockerfile: ./docker-compose/mysql/Dockerfile
-      args:
-        - TAG=${MYSQL_TAG}
+    image: "mysql:${MYSQL_TAG}"
     ports:
         - "3306:3306"
     expose:
         - 3306
     volumes:
         - ./docker-compose/image/mysql/data/:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOTPW}
 
   ####################################################################################################
   # The Redis Server
   ####################################################################################################
   redis:
     container_name: ${REDIS_NAME}_${REDIS_TAG}
-    image: "${REDIS_NAME}:${REDIS_TAG}"
-    build:
-      context: ./
-      dockerfile: ./docker-compose/redis/Dockerfile
-      args:
-        - TAG=${REDIS_TAG}
+    image: "redis:${REDIS_TAG}"
     ports:
         - "6379:6379"
     expose:
@@ -39,7 +31,7 @@ services:
   # Use it with command: docker-compose run redis-cli
   redis-cli:
     container_name: ${NAME}_redis-cli
-    image: "${REDIS_NAME}:${REDIS_TAG}"
+    image: "redis:${REDIS_TAG}"
     links:
       - redis
     command: redis-cli -h redis

--- a/docker-compose/mysql/Dockerfile
+++ b/docker-compose/mysql/Dockerfile
@@ -1,8 +1,0 @@
-ARG TAG
-
-FROM mysql:$TAG
-
-LABEL maintainer="Fabrizio Cafolla <info@fabriziocafolla.com>"
-
-# ADD data in image when build
-ADD ./docker-compose/image/mysql/data/ /var/lib/mysql

--- a/docker-compose/redis/Dockerfile
+++ b/docker-compose/redis/Dockerfile
@@ -1,8 +1,0 @@
-ARG TAG
-
-FROM redis:$TAG
-
-LABEL maintainer="Fabrizio Cafolla <info@fabriziocafolla.com>"
-
-# ADD data in image when build
-ADD ./docker-compose/image/redis/data /data

--- a/docker-compose/workspace/Dockerfile
+++ b/docker-compose/workspace/Dockerfile
@@ -47,22 +47,6 @@ RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     rm /var/log/lastlog /var/log/faillog
 
-# COPY data in image when build
-ADD ./application /var/www
-
 # Set working directory as
 WORKDIR /var/www
 
-# Make permission to workdir
-RUN chown -R www-data:www-data ./* \
-    && chown -R www-data:www-data ./.* \
-    && find . -type f -exec chmod 644 {} \; \
-    && find . -type d -exec chmod 775 {} \;
-
-ARG COMPOSER_UPDATE
-
-RUN if [ $COMPOSER_UPDATE = "true" ]; then \
-    composer update \
-;fi
-
-RUN cp ./.env.example .env

--- a/readme.md
+++ b/readme.md
@@ -1,18 +1,32 @@
-# DevOps Microservice Lumen Project
-[build] [stable]
+# Microservice Lumen - DevOps 
+![](https://img.shields.io/badge/version-1.5.0--beta-green.svg)
+![](https://img.shields.io/badge/docker--compose-build-blue.svg)
+![](https://img.shields.io/badge/docker-build-blue.svg)
 
-\[version] [v1.4.2  beta]
+### Let's go
+    /*dev env*/
+    cp .env.docker .env
+    docker-compose build
+    docker-compose up -d
+    /*only first time*/
+    docker-compose exec workspace bash
+    cp ./.env.example .env
+    php artisan jwt:secret -f
+    
+    /*prod env*/
+    docker build --tag microservice-lumen .
+    docker run -d -p 9000:9000 --name name-of-container -it microservice-lumen /bin/bash
 
-##### Why use it?
->Microservice Lumen allows you to start from a solid foundation to build your backend. Using packages, services and patterns you'll be able to implement your app in an easy and efficient way. With this framework you can build your REST API in a few steps using artisan commands to create the Controller, the Repository linked to the data model and the Trasformer for data display. The microservice communicates with the outside through HTTP API calls with JWT authentication (stateless token). It implements base services for API controller, response and helpers.
+    /*pull container from dockergub (tagname: develop or latest)*/
+    docker pull fabriziocaf/microservice-lumen:tagname
+    
+[Wiki](https://github.com/FabrizioCafolla/microservice-lumen/wiki)
 
-## Official Documentation
+[Documentation Api](https://fabriziocafolla.com/docs/microservice-lumen/)
 
-![](.github/Microservice-lumen-image.jpg)
+### Features 
 
-## Features 
-
-**Doker** to start the application with `Nginx`, `PHP 7`, `MySQL` and `Redis`;
+**Doker** to start the application with `Nginx`, `PHP 7.2.2-fpm`, `MySQL` and `Redis`;
 
 **JWT** for the authentication of routes usable with the implemented service;
 
@@ -33,12 +47,16 @@
   
 **Artisan commands** to create Repository, ApiController, Provider and Transoformers (Other commands to create example file view documentation)
 
-[Wiki](https://github.com/FabrizioCafolla/microservice-lumen/wiki)
+### Changelog
 
-[Documentation Api](https://fabriziocafolla.com/microservice-lumen/docs/)
-
-[File example](https://gist.github.com/FabrizioCafolla/b132d6eafbb5c851b7610f8cf927bdf4)
-
+  ##### v1.5.0 beta
+    -Update directory and docker file
+    -Update core package 
+    -Update response package with new logic 
+    -Update and clean code cahce package 
+    -Fixed rest controllers
+    -Clean code
+    
   ##### v1.4.2 beta
     -Update core package 
     -Update response package 


### PR DESCRIPTION
Readme must be updated:
1. After `docker-compose exec workspace bash` composer install is needed to run.

------
#### commit Workspace Dockerfile cleaning
Removed unused commands from workspace dockerfile
`ADD` is not used because file added during build are overwritten by volumes 
`composer` must be executed after build, so in Dockerfile is not used
`cp .env` is unused because is overwritten by volumes files


------
#### commit Mysql + Redis ADD fix

1. removed mysql and redis dockerfile. Tag image in docker-compose file is already selecting the right image, so dockerfile is not required.

-------


## Changes are tested.
